### PR TITLE
Edited paths

### DIFF
--- a/README.md
+++ b/README.md
@@ -54,20 +54,20 @@ Below is an example using the Oak server framework. To get started, import Dashp
 
 ```typescript
 // 'server.ts' file
-import { DashportOak } from 'https://deno.land/x/dashport/mod.ts';
+import { DashportOak } from 'https://deno.land/x/dashport@v1.2.1/mod.ts';
 ```
 
 In the future, additional Dashports can be imported from the same mod.ts file. For example if Express was supported in Deno:
 
 ```typescript
-import { DashportExpress } from 'https://deno.land/x/dashport/mod.ts';
+import { DashportExpress } from 'https://deno.land/x/dashport@v1.2.1/mod.ts';
 ```
 
 After importing Dashport, import Application from Oak and instantiate it.
 
 ```typescript
 // 'server.ts' file
-import DashportOak from 'https://deno.land/x/dashport/mod.ts';
+import { DashportOak } from 'https://deno.land/x/dashport@v1.2.1/mod.ts';
 import { Application } from "https://deno.land/x/oak/mod.ts";
 
 const app = new Application();
@@ -77,7 +77,7 @@ Then instantiate Dashport and pass in the Application instance. This is needed i
 
 ```typescript
 // 'server.ts' file
-import DashportOak from 'https://deno.land/x/dashport/mod.ts';
+import { DashportOak } from 'https://deno.land/x/dashport@v1.2.1/mod.ts';
 import { Application } from "https://deno.land/x/oak/mod.ts";
 
 const app = new Application();
@@ -87,7 +87,7 @@ const dashport = new DashportOak(app);
 Routes can then be added as needed
 
 ```typescript
-import DashportOak from 'https://deno.land/x/dashport/mod.ts';
+import { DashportOak } from 'https://deno.land/x/dashport@v1.2.1/mod.ts';
 import { Application, Router } from 'https://deno.land/x/oak/mod.ts';
 
 const app = new Application();
@@ -269,7 +269,7 @@ const deserializerA = async (serializedId: (string | number)) => {
 
 ```typescript
 // Oak example
-import DashportOak from 'https://deno.land/x/dashport/mod.ts';
+import { DashportOak } from 'https://deno.land/x/dashport@v1.2.1/mod.ts';
 import { Application, Router } from 'https://deno.land/x/oak/mod.ts';
 import { ghStrat, serializerB, deserializerB } from './dashportConfig.ts';
 

--- a/__tests__/dashportOak.test.js
+++ b/__tests__/dashportOak.test.js
@@ -1,5 +1,5 @@
 import { Application, assertEquals, assertThrows, assertThrowsAsync } from "../deps.ts";
-import DashportOak from '../frameworks/dashportOak.ts';
+import DashportOak from '../dashports/dashportOak.ts';
 
 // Mock class and functions
 class TestStrat {


### PR DESCRIPTION
importing DashportOak with 'https://deno.land/x/dashport/mod.ts'; pulls from v1.0.1; changed import to explicitly call 'https://deno.land/x/dashport@v1.2.0/mod.ts';